### PR TITLE
Fix for PowerShell 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const friendlyName = program.name
 function init(){
   const ps2 = new Shell({executionPolicy: 'Bypass'})
   console.log(`Writing cert ${program.dns} with exp in ${program.exp} hours named ${friendlyName}`)
+  ps2.addCommand('$env:PSModulePath = [Environment]::GetEnvironmentVariable("PSModulePath", "Machine")')
   if(!program.noclear) {
     ps2.addCommand('$store = new-object System.Security.Cryptography.X509Certificates.X509Store([System.Security.Cryptography.X509Certificates.StoreName]::Root,"currentuser")')
     ps2.addCommand('$x=$store.Open("MaxAllowed")')


### PR DESCRIPTION
When running `win-cert-gen -d local.site.com -e 720` on PowerShell 7.x we get the error message `New-SelfSignedCertificate : Cannot find drive. A drive with the name 'Cert' does not exist.`. 

Loading the `PSModulePath` env variable fixes the issue.

Tested on PowerShell 7.5.0-rc.1 and Windows 11.